### PR TITLE
Stop subscripting None

### DIFF
--- a/src/python-loops.py
+++ b/src/python-loops.py
@@ -65,11 +65,13 @@ def calc_wait_time(interval: float):
 
 
 async def yt_checker(channel_id):
-    channel = scrapetube.get_channel(channel_id)
+    channel = scrapetube.get_channel(channel_id, limit=1)
     latest_video = None
     for video in channel:
         latest_video = video
         break
+    if latest_video is None:
+        return
     video = Video(latest_video["videoId"])
     channel_cache = json.loads(open("./src/youtube.json", "r").read())
     if video.channel_id not in channel_cache:


### PR DESCRIPTION
Adds a check to stop executing if latest_video is None because scrapetube did not retrieve videos. I don't know why that happens, but maybe adding a limit will help. Almost certainly not because scrapetube is a generator, but maybe?

If that doesn't do anything for the missing videos a potential fix might be more evenly spreading out the requests. So instead of this:
https://github.com/BobVonBob/Bitey-Frank/blob/8464c69a6cf36abf496ba9db549902f7c266de5f/src/python-loops.py#L131-L133
we could try this:
```py
        for channel in channels:
            await (yt_checker(channel))
            await asyncio.sleep(calc_wait_time(60))
```
so all of the channels aren't being grabbed at the same time.